### PR TITLE
Feature/#2

### DIFF
--- a/src/rex.nim
+++ b/src/rex.nim
@@ -17,30 +17,30 @@ proc next*[T](observable: Observable[T], value: T) =
     observer(value)
 
 proc create*[T](process: proc(observable: Observable[T])): Observable[T] =
-  let result = Observable[T]()
+  result = Observable[T]()
   process(result)
   return result
 
 proc map*[T, R](source: Observable[T], mapper: proc(value: T): R ): Observable[R] =
   ## Applies a given `mapper` function to each value emitted by `source`.
   ## Emits the mapped values in a new Observable
-  let result = Observable[R]()
+  let newObservable = Observable[R]()
   proc observer(value: T) =
-    result.next(mapper(value))
+    newObservable.next(mapper(value))
   source.subscribe(observer)
-  return result
+  return newObservable
 
 proc filter*[T](source: Observable[T], filter: proc(value: T): bool {.noSideEffect.}): Observable[T] =
   ## Filters items emitted by `source` by only emitting those that satisfy the
   ## specified `filter` function. The filtered values are emitted as a new Observable.
-  let result = Observable[T]()
+  let newObservable = Observable[T]()
   proc observer(value: T) =
     if filter(value):
-      result.next(value)
+      newObservable.next(value)
       
   source.subscribe(observer)
   
-  return result
+  return newObservable
 
 proc tap*[T](source: Observable[T], sideEffect: proc(value: T)): Observable[T] =
   ## Performs side effects in `sideEffect` every time `source` emits a value. 
@@ -54,7 +54,7 @@ proc tap*[T](source: Observable[T], sideEffect: proc(value: T)): Observable[T] =
 proc throttle*[T](source: Observable[T], throttleProc: proc(value: T): Duration): Observable[T] =
   ## Receives a proc to compute the silencing duration for each value emitted by `source`.
   ## During the silencing duration any value emitted by `source` will be ignored.
-  let result = Observable[T]()
+  let newObservable = Observable[T]()
   var lastTriggerTime: MonoTime 
   proc observer(value: T) =
     let delay: Duration = throttleProc(value)
@@ -62,29 +62,96 @@ proc throttle*[T](source: Observable[T], throttleProc: proc(value: T): Duration)
     let elapsed = (now - lastTriggerTime)
     if elapsed >= delay:
       lastTriggerTime = now
-      result.next(value)
+      newObservable.next(value)
       
   source.subscribe(observer)
-  return result
+  return newObservable
 
 proc combine*[T, R](
   source1: Observable[T], 
   source2: Observable[R]
 ): Observable[(T, R)] =
-  ## Combines the latest values from `source1` and `source2` and emits them as a tuple in a new Observable.
-  ## This Observable emits every time either `source1` or `source2` emit.
-  let result = Observable[(T, R)]()
+  ## Combines the latest values from the given observables and emits them as a tuple in a new Observable.
+  ## This Observable emits every time any of the sources emit.
+  let newObservable = Observable[(T, R)]()
   
   var latestsource1Value: T = source1.lastValue
   var latestsource2Value: R = source2.lastValue
   proc source1Observer(value1: T) =
     latestSource1Value = value1
-    result.next((value1, latestSource2Value))
+    newObservable.next((value1, latestSource2Value))
   source1.subscribe(source1Observer)
   
   proc source2Observer(value2: R) =
     latestSource2Value = value2
-    result.next((latestSource1Value, value2))
+    newObservable.next((latestSource1Value, value2))
   source2.subscribe(source2Observer)
   
-  return result
+  return newObservable
+
+proc combine*[T, R, S](
+  source1: Observable[T], 
+  source2: Observable[R],
+  source3: Observable[S]
+): Observable[(T, R, S)] =
+  ## Combines the latest values from the given observables and emits them as a tuple in a new Observable.
+  ## This Observable emits every time any of the sources emit.
+  let newObservable = Observable[(T, R, S)]()
+  
+  var latestSource1Value: T = source1.lastValue
+  var latestSource2Value: R = source2.lastValue
+  var latestSource3Value: S = source3.lastValue
+  
+  proc source1Observer(value1: T) =
+    latestSource1Value = value1
+    newObservable.next((value1, latestSource2Value, latestSource3Value))
+  source1.subscribe(source1Observer)
+  
+  proc source2Observer(value2: R) =
+    latestSource2Value = value2
+    newObservable.next((latestSource1Value, value2, latestSource3Value))
+  source2.subscribe(source2Observer)
+  
+  proc source3Observer(value3: S) =
+    latestSource3Value = value3
+    newObservable.next((latestSource1Value, latestSource2Value, value3))
+  source3.subscribe(source3Observer)
+  
+  return newObservable
+
+proc combine*[T, R, S, Q](
+  source1: Observable[T], 
+  source2: Observable[R],
+  source3: Observable[S],
+  source4: Observable[Q]
+): Observable[(T, R, S, Q)] =
+  ## Combines the latest values from the given observables and emits them as a tuple in a new Observable.
+  ## This Observable emits every time any of the sources emit.
+  let newObservable = Observable[(T, R, S, Q)]()
+  
+  var latestSource1Value: T = source1.lastValue
+  var latestSource2Value: R = source2.lastValue
+  var latestSource3Value: S = source3.lastValue
+  var latestSource4Value: Q = source4.lastValue
+  
+  proc source1Observer(value1: T) =
+    latestSource1Value = value1
+    newObservable.next((value1, latestSource2Value, latestSource3Value, latestSource4Value))
+  source1.subscribe(source1Observer)
+  
+  proc source2Observer(value2: R) =
+    latestSource2Value = value2
+    newObservable.next((latestSource1Value, value2, latestSource3Value, latestSource4Value))
+  source2.subscribe(source2Observer)
+  
+  proc source3Observer(value3: S) =
+    latestSource3Value = value3
+    newObservable.next((latestSource1Value, latestSource2Value, value3, latestSource4Value))
+  source3.subscribe(source3Observer)
+
+  proc source4Observer(value4: Q) =
+    latestSource4Value = value4
+    newObservable.next((latestSource1Value, latestSource2Value, latestSource3Value, value4))
+  source4.subscribe(source4Observer)
+  
+  return newObservable

--- a/src/rex.nim
+++ b/src/rex.nim
@@ -1,3 +1,5 @@
+import std/[times, monotimes]
+
 type Observable*[T] = ref object
   observers: seq[proc(value: T)]
   lastValue: T
@@ -17,4 +19,72 @@ proc next*[T](observable: Observable[T], value: T) =
 proc create*[T](process: proc(observable: Observable[T])): Observable[T] =
   let result = Observable[T]()
   process(result)
+  return result
+
+proc map*[T, R](source: Observable[T], mapper: proc(value: T): R ): Observable[R] =
+  ## Applies a given `mapper` function to each value emitted by `source`.
+  ## Emits the mapped values in a new Observable
+  let result = Observable[R]()
+  proc observer(value: T) =
+    result.next(mapper(value))
+  source.subscribe(observer)
+  return result
+
+proc filter*[T](source: Observable[T], filter: proc(value: T): bool {.noSideEffect.}): Observable[T] =
+  ## Filters items emitted by `source` by only emitting those that satisfy the
+  ## specified `filter` function. The filtered values are emitted as a new Observable.
+  let result = Observable[T]()
+  proc observer(value: T) =
+    if filter(value):
+      result.next(value)
+      
+  source.subscribe(observer)
+  
+  return result
+
+proc tap*[T](source: Observable[T], sideEffect: proc(value: T)): Observable[T] =
+  ## Performs side effects in `sideEffect` every time `source` emits a value. 
+  ## Returns `source` without changing it.
+  proc observer(value: T) =
+    sideEffect(value)
+  source.subscribe(observer)
+  return source
+
+
+proc throttle*[T](source: Observable[T], throttleProc: proc(value: T): Duration): Observable[T] =
+  ## Receives a proc to compute the silencing duration for each value emitted by `source`.
+  ## During the silencing duration any value emitted by `source` will be ignored.
+  let result = Observable[T]()
+  var lastTriggerTime: MonoTime 
+  proc observer(value: T) =
+    let delay: Duration = throttleProc(value)
+    let now = getMonoTime()
+    let elapsed = (now - lastTriggerTime)
+    if elapsed >= delay:
+      lastTriggerTime = now
+      result.next(value)
+      
+  source.subscribe(observer)
+  return result
+
+proc combine*[T, R](
+  source1: Observable[T], 
+  source2: Observable[R]
+): Observable[(T, R)] =
+  ## Combines the latest values from `source1` and `source2` and emits them as a tuple in a new Observable.
+  ## This Observable emits every time either `source1` or `source2` emit.
+  let result = Observable[(T, R)]()
+  
+  var latestsource1Value: T = source1.lastValue
+  var latestsource2Value: R = source2.lastValue
+  proc source1Observer(value1: T) =
+    latestSource1Value = value1
+    result.next((value1, latestSource2Value))
+  source1.subscribe(source1Observer)
+  
+  proc source2Observer(value2: R) =
+    latestSource2Value = value2
+    result.next((latestSource1Value, value2))
+  source2.subscribe(source2Observer)
+  
   return result

--- a/tests/test_rex.nim
+++ b/tests/test_rex.nim
@@ -152,7 +152,7 @@ suite "Operators - throttle":
     
     let throttledObservable = observable
       .throttle(proc(value: int): Duration = initDuration(milliseconds = 100))
-      .tap(proc(value: int) = echo value)
+
     # When
     var receivedValues: seq[int] = @[]
     throttledObservable.subscribe(proc(value: int) = receivedValues.add(value))
@@ -164,7 +164,7 @@ suite "Operators - throttle":
     # Then
     assert receivedValues == @[1, 3]
 
-suite "Operators - combine":
+suite "Operators - combine 2 parameters":
   test "combine of same type":
     # Given
     let observable1 = create[int](
@@ -212,3 +212,96 @@ suite "Operators - combine":
     
     # Then
     assert receivedValues == @[(1, "2"), (3, "2"), (3, "4")]
+
+suite "Operators - combine 3 parameters":
+  test "combine of same type":
+    # Given
+    let observable1 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    let observable2 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(2)
+    )
+    let observable3 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(3)
+    )
+    
+    let combinedObservable = combine(observable1, observable2, observable3)
+    
+    # When
+    var receivedValues: seq[(int, int, int)] = @[]
+    combinedObservable.subscribe(proc(value: (int, int, int)) = receivedValues.add(value))
+    
+    observable1.next(3)
+    observable2.next(4)
+    observable3.next(5)
+    
+    # Then
+    assert receivedValues == @[(1, 2, 3), (3, 2, 3), (3, 4, 3), (3, 4, 5)]
+  
+  test "combine of different types":
+    # Given
+    let observable1 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    
+    let observable2 = create[string](
+      proc(obs: Observable[string]) =
+        obs.next("2")
+    )
+    
+    let observable3 = create[bool](
+      proc(obs: Observable[bool]) =
+        obs.next(true)
+    )
+    
+    let combinedObservable = combine(observable1, observable2, observable3)
+    
+    # When
+    var receivedValues: seq[(int, string, bool)] = @[]
+    combinedObservable.subscribe(proc(value: (int, string, bool)) = receivedValues.add(value))
+    
+    observable1.next(3)
+    observable2.next("4")
+    observable3.next(false)
+    
+    # Then
+    assert receivedValues == @[(1, "2", true), (3, "2", true), (3, "4", true), (3, "4", false)]
+
+suite "Operators - combine 4 parameters":
+  test "combine of same type":
+    # Given
+    let observable1 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    let observable2 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(2)
+    )
+    let observable3 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(3)
+    )
+    let observable4 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(4)
+    )
+    
+    let combinedObservable = combine(observable1, observable2, observable3, observable4)
+    
+    # When
+    var receivedValues: seq[(int, int, int, int)] = @[]
+    combinedObservable.subscribe(proc(value: (int, int, int, int)) = receivedValues.add(value))
+    
+    observable1.next(3)
+    observable2.next(4)
+    observable3.next(5)
+    observable4.next(6)
+    
+    # Then
+    assert receivedValues == @[(1, 2, 3, 4), (3, 2, 3, 4), (3, 4, 3, 4), (3, 4, 5, 4), (3, 4, 5, 6)]

--- a/tests/test_rex.nim
+++ b/tests/test_rex.nim
@@ -1,7 +1,7 @@
 # test_rex.nim
 
-import unittest
 import rex
+import std/[times, os, unittest]
 
 suite "Observable":
   test "subscribe and next":
@@ -58,3 +58,157 @@ suite "Observable":
 
     observable.subscribe(lateObserver)
     assert receivedValue == 3
+
+suite "Operators - map": 
+  test "map from int to int":
+    # Given
+    let observable = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    
+    let mappedObservable = observable
+      .map(proc(value: int): int = value * 2)
+    
+    # When
+    var receivedValues: seq[int] = @[]
+    mappedObservable.subscribe(proc(value: int) = receivedValues.add(value))
+    
+    observable.next(2)
+    observable.next(3)
+    
+    # Then
+    assert receivedValues == @[2, 4, 6]
+    
+  test "map from int to string":
+    # Given
+    let observable = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    
+    let mappedObservable = observable
+      .map(proc(value: int): string = $value)
+    
+    # When
+    var receivedValues: seq[string] = @[]
+    mappedObservable.subscribe(proc(value: string) = receivedValues.add(value))
+    
+    observable.next(2)
+    observable.next(3)
+    
+    # Then
+    assert receivedValues == @["1", "2", "3"]
+
+suite "Operators - tap":
+  test "tap":
+    # Given
+    let observable = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    
+    var receivedValues: seq[int] = @[]
+    let tappedObservable = observable
+      .tap(proc(value: int) = receivedValues.add(value))
+    
+    # When
+    observable.next(2)
+    observable.next(3)
+    
+    # Then
+    assert receivedValues == @[1, 2, 3]
+
+suite "Operators - filter":
+  test "filter":
+    # Given
+    let observable = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+        obs.next(2)
+        obs.next(3)
+    )
+    
+    let filteredObservable = observable
+      .filter(proc(value: int): bool = value mod 2 == 0)
+    
+    # When
+    var receivedValues: seq[int] = @[]
+    filteredObservable.subscribe(proc(value: int) = receivedValues.add(value))
+    
+    observable.next(2)
+    observable.next(3)
+    
+    # Then
+    assert receivedValues == @[2]
+
+suite "Operators - throttle":
+  test "throttle":
+    # Given
+    let observable = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    
+    let throttledObservable = observable
+      .throttle(proc(value: int): Duration = initDuration(milliseconds = 100))
+      .tap(proc(value: int) = echo value)
+    # When
+    var receivedValues: seq[int] = @[]
+    throttledObservable.subscribe(proc(value: int) = receivedValues.add(value))
+    
+    observable.next(2)
+    sleep(100)
+    observable.next(3)
+    
+    # Then
+    assert receivedValues == @[1, 3]
+
+suite "Operators - combine":
+  test "combine of same type":
+    # Given
+    let observable1 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    
+    let observable2 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(2)
+    )
+    
+    let combinedObservable = combine(observable1, observable2)
+    
+    # When
+    var receivedValues: seq[(int, int)] = @[]
+    combinedObservable.subscribe(proc(value: (int, int)) = receivedValues.add(value))
+    
+    observable1.next(3)
+    observable2.next(4)
+    
+    # Then
+    assert receivedValues == @[(1, 2), (3, 2), (3, 4)]
+  
+  test "combine of different types":
+    # Given
+    let observable1 = create[int](
+      proc(obs: Observable[int]) =
+        obs.next(1)
+    )
+    
+    let observable2 = create[string](
+      proc(obs: Observable[string]) =
+        obs.next("2")
+    )
+    
+    let combinedObservable = combine(observable1, observable2)
+    
+    # When
+    var receivedValues: seq[(int, string)] = @[]
+    combinedObservable.subscribe(proc(value: (int, string)) = receivedValues.add(value))
+    
+    observable1.next(3)
+    observable2.next("4")
+    
+    # Then
+    assert receivedValues == @[(1, "2"), (3, "2"), (3, "4")]


### PR DESCRIPTION
Adds the following operators: 
- Combine (combines 2 observables and only 2 observables)
- tap (execute a side effect without changing observable)
- map (map value in observable to new value)
- filter (ignore values from observable that don't satisfy a given filter function)
- throttle (ignore values emitted by source for a given silence-time)

Depending on the desired move forward regarding combine there are 2 ways to go:
A) I refactor combine to be a macro instead so that it can take arbitrary amounts of observables
B) I add multiple versions of the combine proc for up to 4 different Observables